### PR TITLE
Fixed consul and rdpg-dev to work for new deployments

### DIFF
--- a/packages/consul-ui/packaging
+++ b/packages/consul-ui/packaging
@@ -2,10 +2,9 @@
 set -e
 
 package="consul-ui"
-version="0.5.0"
+version="0.5.2"
 file="${package}-${version}.zip"
 
 unzip ${package}/${file}
 
 cp -a dist/* $BOSH_INSTALL_TARGET
-

--- a/packages/consul-ui/prepare
+++ b/packages/consul-ui/prepare
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -x
 package="consul-ui"
-version="0.5.0"
+version="0.5.2"
 file="${package}-${version}.zip"
-url="https://dl.bintray.com/mitchellh/consul/${version}_web_ui.zip"
+url="https://releases.hashicorp.com/consul/${version}/consul_${version}_web_ui.zip"
 
 if [[ ! -s "${package}/${file}" ]]
 then

--- a/packages/consul/prepare
+++ b/packages/consul/prepare
@@ -3,7 +3,7 @@ set -x
 package="consul"
 version="0.5.2"
 file="${package}-${version}.zip"
-url="https://dl.bintray.com/mitchellh/consul/${version}_linux_amd64.zip"
+url="https://releases.hashicorp.com/consul/${version}/consul_${version}_linux_amd64.zip"
 
 if [[ ! -s "${package}/${file}" ]]
 then

--- a/rdpg-dev
+++ b/rdpg-dev
@@ -145,6 +145,11 @@ prepare_dev_release() {
   bosh -n upload release
 }
 
+create_folders() {
+  [[ -d ${releasePath}/stemcells ]] || mkdir ${releasePath}/stemcells
+  [[ -d ${releasePath}/manifests ]] || mkdir ${releasePath}/manifests
+}
+
 prepare_manifest() {
   select_infrastructure $*
   determine_stemcell $*
@@ -167,7 +172,7 @@ prepare_manifest() {
     "${templatesPath}/stub.yml" > "${tmpPath}/targeted-director-stub.yml"
 
   echo "Merging templates using spruce..."
-  
+
   if [[ ! -f ${templatesPath}/s3.yml ]]
   then
     cp ${templatesPath}/.defaults/s3.yml ${templatesPath}/
@@ -225,6 +230,7 @@ case ${action} in
       usage
       fail
     fi
+    create_folders
     prepare_blobs
     prepare_dev_release
     prepare_stemcell "${args[@]}"


### PR DESCRIPTION
This change was originally posted by github user jaustinhughey:

Fixes GitHub issues #135 and #136.

Problem originally caused by the source where bosh gets those files being at bintray.com, and the user who had those files under his account has deleted them. This PR changes the location from which
bosh retrieves the needed files to Hashicorp's "official" releases CDN, releases.hashicorp.com.

Version Changes:

consul: none, still at 0.5.2.
consul-ui: minor version bump from 0.5.0 to 0.5.2 since I didn't see a 0.5.0 available in the official releases CDN. Assuming they're following semantic versioning, this shouldn't be a breaking change at all.
Caveats/Notes/FYIs:

There are three consul-related packages in this repo:

consul
consul-ui
consul-template
The first two now fetch from Hashicorp's releases CDN, but the last one, consul-template, is still fetching from GitHub releases, NOT the CDN. I didn't change this because it wasn't absolutely necessary and I'm hesitant to make any changes that aren't totally necessary without first consulting the team as a whole.

If you stick with the GitHub releases path, the major problems I can foresee might be a repository rename, removal of old releases, or even Hashicorp changing their name (or something). In short, the same issue I'm fixing right now.

However, you run into the same issues with going to the CDN releases URL instead. Say Hashicorp moves back to a releases "provider" like bintray again in the future. Who's to say they won't just nuke what's at releases.hashicorp.com at that point and just not tell anyone or not provide a redirect, like they failed to do with bintray?

Either way there are risks (although my opinion is the releases.hashicorp.com route is safer by a small to moderate degree), but I feel the team or individual(s) most in touch with this project should talk and make that decision amongst themselves before I shove it in this PR.

Feedback on this PR is welcome; let me know if there's anything that needs to be changed before it can be merged to the develop or other branches.
