### PR TITLE
Reset password on unbind

### DIFF
--- a/ci/tests/provision_change_password
+++ b/ci/tests/provision_change_password
@@ -52,17 +52,35 @@ echo "Unbinding..."
 unbind="$(curl -s -X DELETE -H "X-Broker-API-Version: 2.4" -H "Content-Type: application/json" "http://cfadmin:cfadmin@${bindIp}:8888/v2/service_instances/${instanceId}/service_bindings/${bindingId}" | jq '.Status')"
 if [[ "$unbind" != "200" ]] ; then fail "Unbind was not successful!" ; fi
 
+
+echo "Waiting 35 seconds for password to be updated..."
+sleep 35
+
+echo "Bind instance a second time..."
+URI="$(curl -s -X PUT -H "X-Broker-API-Version: 2.4" -H "Content-Type: application/json" "http://cfadmin:cfadmin@${bindIp}:8888/v2/service_instances/${instanceId}/service_bindings/${bindingId}" -d "{ \"service_id\": \"${serviceId}\", \"plan_id\": \"${planId}\", \"app_guid\": \"${appId}\"}" | jq '.credentials.uri' | tr -d '"')"
+echo "URI: ${URI}"
+
+if [[ -z ${URI} ]] ; then fail "Could not determine URI!" ; fi
+
+echo "Using URI to connect to database..."
+psql "${URI}" -t -c "SELECT true;"
+while [ $? -ne 0 ]; do
+  echo "Waiting 5 seconds and trying again..."
+  sleep 5
+  psql "${URI}" -t -c "SELECT true;"
+done
+
+echo "Unbinding, again..."
+unbind="$(curl -s -X DELETE -H "X-Broker-API-Version: 2.4" -H "Content-Type: application/json" "http://cfadmin:cfadmin@${bindIp}:8888/v2/service_instances/${instanceId}/service_bindings/${bindingId}" | jq '.Status')"
+if [[ "$unbind" != "200" ]] ; then fail "Unbind was not successful!" ; fi
+
 echo "Deprovisioning..."
 deprovision="$(curl -s -X DELETE -H "X-Broker-API-Version: 2.4" -H "Content-Type: application/json" "http://cfadmin:cfadmin@${bindIp}:8888/v2/service_instances/${instanceId}" | jq '.Status')"
 if [[ "$deprovision" != "200" ]] ; then fail "Deprovisioning was not successful!" ; fi
 
 echo "Using URI to connect to database..."
+sleep 5
 psql "${URI}" -t -c "SELECT true;"
-while [ $? -eq 0 ]; do
-  echo "Waiting 5 seconds and trying again..."
-  sleep 5
-  psql "${URI}" -t -c "SELECT true;"
-done
 
 if [[ $? -eq 0 ]] ; then fail "Could still connect to the database after deprovisioning!" ; fi
 

--- a/src/rdpgd/gpb/pgbouncer.go
+++ b/src/rdpgd/gpb/pgbouncer.go
@@ -35,10 +35,13 @@ func Work() {
 
 	for {
 
+		start := time.Now()
 		err := configureGlobalPGBouncer()
 		if err != nil {
 			log.Error(fmt.Sprintf(`gpb.configureGlobalPGBouncer() ! Error: %s`, err))
 		}
+		duration := int(time.Since(start).Seconds())
+		log.Info(fmt.Sprintf(`It took %d seconds to process configureGlobalPGBouncer()...`, duration))
 
 		log.Info(fmt.Sprintf(`Time goes by, sleeping for %d seconds...`, pgbFrequency))
 		time.Sleep(time.Duration(pgbFrequency) * time.Second)


### PR DESCRIPTION
This commit changes the unbind behavior for non-bdr databases.  When a user unbinds their database a new password is generated.

This feature allows the developers to cycle their passwords for compliance reasons.  To leverage a password change the developer simply needs to unbind, bind and restage their CF app.

This change is testable by running:
ci/tests/provision_change_password
